### PR TITLE
added reasonable clipboard default for Linux

### DIFF
--- a/lib/bubs.rb
+++ b/lib/bubs.rb
@@ -66,6 +66,7 @@ class Bubs
     end.join('')
 
     `echo "#{bubbled}" | pbcopy` if RUBY_PLATFORM =~ /darwin/
+    `echo "#{bubbled}" | xclip` if RUBY_PLATFORM =~ /linux/
     puts bubbled
   end
 end


### PR DESCRIPTION
May also use `xsel` as that is common as well.  Or `klipper` for KDE users.
