### PR TITLE
Ⓐⓓⓓ --ⓝⓞ-ⓒⓞⓟⓨ ⓣⓞ ⓟⓡⓔⓥⓔⓝⓣ ⓞⓥⓔⓡⓦⓡⓘⓣⓘⓝⓖ ⓒⓛⓘⓟⓑⓞⓐⓡⓓ

### DIFF
--- a/bin/bubs
+++ b/bin/bubs
@@ -2,6 +2,8 @@
 $:.unshift File.expand_path('../../lib', __FILE__)
 require 'bubs'
 
+do_copy = !ARGV.delete_at(ARGV.index('--no-copy') || ARGV.length)
+
 text = Bubs.convert(ARGV.join(' '))
-Bubs.copy(text)
+Bubs.copy(text) if do_copy
 puts text


### PR DESCRIPTION
Allows bubs to be used in shell scripts without side effects:

```
$ git commit -am "$(bubs --no-copy I do not need this in my clipboard)"
```
